### PR TITLE
Update build to .NET 6; update Autofac.Owin to 7.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,23 +48,31 @@ dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 
 ; Name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
 dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
 dotnet_naming_symbols.constant_fields.applicable_kinds   = field
 dotnet_naming_symbols.constant_fields.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
-; Static fields should be PascalCase
-dotnet_naming_rule.static_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.static_fields_should_be_pascal_case.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_be_pascal_case.style    = pascal_case_style
+; Static fields should be _camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
 dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
 
+; Static readonly fields should be PascalCase
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols  = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
+
 ; Internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
 dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
 dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
@@ -120,6 +128,7 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Other features
+csharp_style_namespace_declarations = file_scoped:suggestion
 csharp_style_prefer_index_operator = false:none
 csharp_style_prefer_range_operator = false:none
 csharp_style_pattern_local_over_anonymous_function = false:none

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# Ignore revisions in git blame - set your git config to use the file by convention:
+# git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Optional additional git config:
+# Mark any lines that have had a commit skipped using --ignore-rev with a `?`
+# git config --global blame.markIgnoredLines true
+# Mark any lines that were added in a skipped commit and can not be attributed with a `*`
+# git config --global blame.markUnblamableLines true
+
+# Convert to file-scoped namespaces and .NET 6.
+eb145c7e3a70dc911d77dad28cbb9d70cd0a2cca

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "formulahendry.dotnet-test-explorer",
+    "ms-dotnettools.csharp",
+    "editorconfig.editorconfig",
+    "davidanson.vscode-markdownlint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "cSpell.words": [
+    "actnars",
+    "autofac",
+    "browsable",
+    "cref",
+    "inheritdoc",
+    "langword",
+    "notnull",
+    "owin",
+    "paramref",
+    "seealso",
+    "typeparam",
+    "xunit"
+  ],
+  "dotnet-test-explorer.testProjectPath": "test/**/*Test.csproj",
+  "omnisharp.enableEditorConfigSupport": true,
+  "omnisharp.enableRoslynAnalyzers": true
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+  "tasks": [
+    {
+      "args": [
+        "build",
+        "${workspaceFolder}/Autofac.Mvc.Owin.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "command": "dotnet",
+      "group": {
+        "isDefault": true,
+        "kind": "build"
+      },
+      "label": "build",
+      "presentation": {
+        "reveal": "silent"
+      },
+      "problemMatcher": "$msCompile",
+      "type": "shell"
+    }
+  ],
+  "version": "2.0.0"
+}

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,11 +2,11 @@
 <configuration>
   <packageSources>
     <clear/>
+    <add key="Autofac MyGet" value="https://www.myget.org/F/autofac/api/v2" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Xunit MyGet" value="https://myget.org/F/xunit/api/v3/index.json" protocolVersion="3" />
-    <add key="Autofac MyGet" value="https://www.myget.org/F/autofac/api/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>
     <add key="Microsoft and .NET" value="true" />
+    <add key="Autofac MyGet" value="true" />
   </disabledPackageSources>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,58 @@
 # Autofac.Mvc.Owin
+
 OWIN support for the ASP.NET MVC integration for [Autofac](https://autofac.org).
 
-[![Build status](https://ci.appveyor.com/api/projects/status/3fh0r8x7qtbfmv08?svg=true)](https://ci.appveyor.com/project/Autofac/autofac-mvc-owin) [![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/autofac/Autofac.Mvc.Owin)
+[![Build status](https://ci.appveyor.com/api/projects/status/3fh0r8x7qtbfmv08?svg=true)](https://ci.appveyor.com/project/Autofac/autofac-mvc-owin)
 
-Please file issues and pull requests for this package in this repository rather than in the Autofac core repo.
+Please file issues and pull requests for this package [in this repository](https://github.com/autofac/Autofac.Mvc.Owin/issues) rather than in the Autofac core repo.
 
-If you're working with ASP.NET Core, you want [Autofac.Extensions.DependencyInjection](https://www.nuget.org/packages/Autofac.Extensions.DependencyInjection), not this package.
+**If you're working with ASP.NET Core, you want [Autofac.Extensions.DependencyInjection](https://www.nuget.org/packages/Autofac.Extensions.DependencyInjection), not this package.**
 
 - [Documentation](https://autofac.readthedocs.io/en/latest/integration/mvc.html)
 - [NuGet](https://www.nuget.org/packages/Autofac.Mvc5.Owin)
 - [Contributing](https://autofac.readthedocs.io/en/latest/contributors.html)
+- [Open in Visual Studio Code](https://open.vscode.dev/autofac/Autofac.Mvc.Owin)
+
+## Quick Start
+
+If you are using MVC [as part of an OWIN application](https://autofac.readthedocs.io/en/latest/integration/owin.html), you need to:
+
+- Do [all the stuff for standard MVC integration](https://autofac.readthedocs.io/en/latest/integration/mvc.html) - register controllers, set the dependency resolver, etc.
+- Set up your app with the [base Autofac OWIN integration](https://autofac.readthedocs.io/en/latest/integration/owin.html).
+- Add a reference to the [`Autofac.Mvc5.Owin`](https://www.nuget.org/packages/Autofac.Mvc5.Owin/) NuGet package.
+- In your application startup class, register the Autofac MVC middleware after registering the base Autofac middleware.
+
+```c#
+public class Startup
+{
+  public void Configuration(IAppBuilder app)
+  {
+    var builder = new ContainerBuilder();
+
+    // STANDARD MVC SETUP:
+
+    // Register your MVC controllers.
+    builder.RegisterControllers(typeof(MvcApplication).Assembly);
+
+    // Run other optional steps, like registering model binders,
+    // web abstractions, etc., then set the dependency resolver
+    // to be Autofac.
+    var container = builder.Build();
+    DependencyResolver.SetResolver(new AutofacDependencyResolver(container));
+
+    // OWIN MVC SETUP:
+
+    // Register the Autofac middleware FIRST, then the Autofac MVC middleware.
+    app.UseAutofacMiddleware(container);
+    app.UseAutofacMvc();
+  }
+}
+```
+
+**Minor gotcha: MVC doesn't run 100% in the OWIN pipeline.** It still needs `HttpContext.Current` and some other non-OWIN things. At application startup, when MVC registers routes, it instantiates an `IControllerFactory` that ends up creating two request lifetime scopes. It only happens during app startup at route registration time, not once requests start getting handled, but it's something to be aware of. This is an artifact of the two pipelines being mangled together.
+
+Check out the [Autofac ASP.NET MVC integration documentation](https://autofac.readthedocs.io/en/latest/integration/mvc.html) for more information.
+
+## Get Help
+
+**Need help with Autofac?** We have [a documentation site](https://autofac.readthedocs.io/) as well as [API documentation](https://autofac.org/apidoc/). We're ready to answer your questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/autofac) or check out the [discussion forum](https://groups.google.com/forum/#forum/autofac).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 
-version: 6.0.0.{build}
+version: 6.1.0.{build}
 
 dotnet_csproj:
-  version_prefix: '6.0.0'
+  version_prefix: '6.1.0'
   patch: true
   file: 'src\**\*.csproj'
 
@@ -20,19 +20,20 @@ nuget:
 
 clone_depth: 1
 
-test: off
+test: false
 
 build_script:
-  - ps: .\build.ps1
-    
+  - pwsh: .\build.ps1
+
 artifacts:
-  - path: artifacts\packages\**\*.nupkg
+  - path: artifacts\packages\**\*.*nupkg
     name: MyGet
+    type: NuGetPackage
 
 deploy:
-- provider: NuGet
-  server: https://www.myget.org/F/autofac/api/v2/package
-  api_key:
-    secure: xUXExgVAagrdEicCjSxsQVrwiLo2TtnfqMbYB9Cauq2cpbm/EVz957PBK0v/GEYq
-  skip_symbols: false
-  symbol_server: https://www.myget.org/F/autofac/symbols/api/v2/package
+  - provider: NuGet
+    server: https://www.myget.org/F/autofac/api/v2/package
+    symbol_server: https://www.myget.org/F/autofac/api/v2/package
+    api_key:
+      secure: xUXExgVAagrdEicCjSxsQVrwiLo2TtnfqMbYB9Cauq2cpbm/EVz957PBK0v/GEYq
+    artifact: MyGet

--- a/build.ps1
+++ b/build.ps1
@@ -3,44 +3,67 @@
 ########################
 
 Push-Location $PSScriptRoot
-Import-Module $PSScriptRoot\Build\Autofac.Build.psd1 -Force
+try {
+    Import-Module $PSScriptRoot/build/Autofac.Build.psd1 -Force
 
-$artifactsPath = "$PSScriptRoot\artifacts"
-$packagesPath = "$artifactsPath\packages"
-$sdkVersion = (Get-Content "$PSScriptRoot\global.json" | ConvertFrom-Json).sdk.version
+    $artifactsPath = "$PSScriptRoot/artifacts"
+    $packagesPath = "$artifactsPath/packages"
 
-# Clean up artifacts folder
-if (Test-Path $artifactsPath) {
-    Write-Message "Cleaning $artifactsPath folder"
-    Remove-Item $artifactsPath -Force -Recurse
+    $globalJson = (Get-Content "$PSScriptRoot/global.json" | ConvertFrom-Json -NoEnumerate);
+
+    $sdkVersion = $globalJson.sdk.version
+
+    # Clean up artifacts folder
+    if (Test-Path $artifactsPath) {
+        Write-Message "Cleaning $artifactsPath folder"
+        Remove-Item $artifactsPath -Force -Recurse
+    }
+
+    # Install dotnet SDK versions during CI. In a local build we assume you have
+    # everything installed; on CI we'll force the install. If you install _any_
+    # SDKs, you have to install _all_ of them because you can't install SDKs in
+    # two different locations. dotnet CLI locates SDKs relative to the
+    # executable.
+    if ($Null -ne $env:APPVEYOR_BUILD_NUMBER) {
+        Install-DotNetCli -Version $sdkVersion
+        foreach ($additional in $globalJson.additionalSdks)
+        {
+            Install-DotNetCli -Version $additional;
+        }
+    }
+
+    # Write out dotnet information
+    & dotnet --info
+
+    # Set version suffix
+    $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$NULL -ne $env:APPVEYOR_REPO_BRANCH];
+    $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$NULL -ne $env:APPVEYOR_BUILD_NUMBER];
+    $versionSuffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)).Replace('/', '-'))-$revision" }[$branch -eq "master" -and $revision -ne "local"]
+
+    Write-Message "Package version suffix is '$versionSuffix'"
+
+    # Package restore
+    Write-Message "Restoring packages"
+    Get-DotNetProjectDirectory -RootPath $PSScriptRoot | Restore-DependencyPackages
+
+    # Build/package
+    Write-Message "Building projects and packages"
+    Get-DotNetProjectDirectory -RootPath $PSScriptRoot\src | Invoke-DotNetPack -PackagesPath $packagesPath -VersionSuffix $versionSuffix
+
+    # Test
+    Write-Message "Executing unit tests"
+    Get-DotNetProjectDirectory -RootPath $PSScriptRoot\test | Invoke-Test
+
+    if ($env:CI -eq "true") {
+        # Generate Coverage Report
+        Write-Message "Generating Codecov Report"
+        Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+        & bash codecov.sh -f "artifacts/coverage/*/coverage*.info"
+    }
+
+    # Finished
+    Write-Message "Build finished"
 }
-
-# Install dotnet CLI
-Write-Message "Installing .NET Core SDK version $sdkVersion"
-Install-DotNetCli -Version $sdkVersion
-
-# Write out dotnet information
-& dotnet --info
-
-# Set version suffix
-$branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
-$revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
-$versionSuffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
-
-Write-Message "Package version suffix is '$versionSuffix'"
-
-# Package restore
-Write-Message "Restoring packages"
-Get-DotNetProjectDirectory -RootPath $PSScriptRoot | Restore-DependencyPackages
-
-# Build/package
-Write-Message "Building projects and packages"
-Get-DotNetProjectDirectory -RootPath $PSScriptRoot\src | Invoke-DotNetPack -PackagesPath $packagesPath -VersionSuffix $versionSuffix
-
-# Test
-Write-Message "Executing unit tests"
-Get-DotNetProjectDirectory -RootPath $PSScriptRoot\test | Invoke-Test
-
-# Finished
-Write-Message "Build finished"
-Pop-Location
+finally {
+    Pop-Location
+}

--- a/build/Autofac.Build.psm1
+++ b/build/Autofac.Build.psm1
@@ -1,4 +1,4 @@
-# EXIT CODES
+﻿# EXIT CODES
 # 1: dotnet packaging failure
 # 2: dotnet publishing failure
 # 3: Unit test failure
@@ -34,14 +34,7 @@ function Install-DotNetCli {
         [string]
         $Version = "Latest"
     )
-
-    if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue)) {
-        $installedVersion = dotnet --version
-        if ($installedVersion -eq $Version) {
-            Write-Message ".NET Core SDK version $Version is already installed"
-            return;
-        }
-    }
+    Write-Message "Installing .NET SDK version $Version"
 
     $callerPath = Split-Path $MyInvocation.PSCommandPath
     $installDir = Join-Path -Path $callerPath -ChildPath ".dotnet/cli"
@@ -56,15 +49,43 @@ function Install-DotNetCli {
         }
 
         & ./.dotnet/dotnet-install.ps1 -InstallDir "$installDir" -Version $Version
-        $env:PATH = "$installDir;$env:PATH"
     } else {
         if (!(Test-Path ./.dotnet/dotnet-install.sh)) {
             Invoke-WebRequest "https://dot.net/v1/dotnet-install.sh" -OutFile "./.dotnet/dotnet-install.sh"
         }
 
         & bash ./.dotnet/dotnet-install.sh --install-dir "$installDir" --version $Version
-        $env:PATH = "$installDir`:$env:PATH"
     }
+
+    Add-Path "$installDir"
+}
+
+<#
+.SYNOPSIS
+    Appends a given value to the path but only if the value does not yet exist within the path.
+.PARAMETER Path
+    The path to append.
+#>
+function Add-Path {
+    [CmdletBinding()]
+    Param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path
+    )
+
+    $pathSeparator = ":";
+
+    if ($IsWindows) {
+        $pathSeparator = ";";
+    }
+
+    $pathValues = $env:PATH.Split($pathSeparator);
+    if ($pathValues -Contains $Path) {
+      return;
+    }
+
+    $env:PATH = "${Path}${pathSeparator}$env:PATH"
 }
 
 <#
@@ -175,8 +196,7 @@ function Invoke-Test {
                 --configuration Release `
                 --logger:trx `
                 /p:CollectCoverage=true `
-                /p:CoverletOutput="..\..\" `
-                /p:MergeWith="..\..\coverage.json" `
+                /p:CoverletOutput="../../artifacts/coverage/$($Project.Name)/" `
                 /p:CoverletOutputFormat="json%2clcov" `
                 /p:ExcludeByAttribute=CompilerGeneratedAttribute `
                 /p:ExcludeByAttribute=GeneratedCodeAttribute

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -4,13 +4,21 @@
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <Rule Id="CA1707" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Do not directly await a task without calling ConfigureAwait - we need the context for HttpContext.Current and other context propagation. -->
+    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
+    <Rule Id="CA1816" Action="None" />
+    <!-- Mark members static - test methods may not access member data but also can't be static. -->
+    <Rule Id="CA1822" Action="None" />
+    <!-- Do not directly await a task - this is for libraries rather than test code. -->
     <Rule Id="CA2007" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Use Uri instead of string parameters - strings are easier for testing. -->
+    <Rule Id="CA2234" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
@@ -36,6 +44,10 @@
     <Rule Id="SA1309" Action="None" />
     <!-- Suppressions must have a justification -->
     <Rule Id="SA1404" Action="None" />
+    <!-- Elements should be documented -->
+    <Rule Id="SA1600" Action="None" />
+    <!-- Enuemration items should be documented -->
+    <Rule Id="SA1602" Action="None" />
     <!-- Parameter documentation must be in the right order -->
     <Rule Id="SA1612" Action="None" />
     <!-- Return value must be documented -->
@@ -48,5 +60,11 @@
     <Rule Id="SA1627" Action="None" />
     <!-- Enable XML documentation output-->
     <Rule Id="SA1652" Action="None" />
+    <!-- Private member is unused - tests for reflection require members that may not get used. -->
+    <Rule Id="IDE0051" Action="None" />
+    <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->
+    <Rule Id="IDE0052" Action="None" />
+    <!-- Remove unused parameter - tests for reflection require parameters that may not get used. -->
+    <Rule Id="IDE0060" Action="None" />
   </Rules>
 </RuleSet>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  branch: develop
+  require_ci_to_pass: yes
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.302",
-    "rollForward": "latestFeature"
+    "rollForward": "latestFeature",
+    "version": "6.0.301"
   }
 }

--- a/src/Autofac.Integration.Mvc.Owin/Autofac.Integration.Mvc.Owin.csproj
+++ b/src/Autofac.Integration.Mvc.Owin/Autofac.Integration.Mvc.Owin.csproj
@@ -54,8 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="[6.0.0, 7.0.0)" />
-    <PackageReference Include="Autofac.Owin" Version="[6.0.0, 7.0.0)" />
+    <PackageReference Include="Autofac.Owin" Version="7.0.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Autofac.Integration.Mvc.Owin/Autofac.Integration.Mvc.Owin.csproj
+++ b/src/Autofac.Integration.Mvc.Owin/Autofac.Integration.Mvc.Owin.csproj
@@ -1,40 +1,52 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-    <SignAssembly>true</SignAssembly>
     <!-- VersionPrefix patched by AppVeyor -->
     <VersionPrefix>0.0.1</VersionPrefix>
-    <AssemblyOriginatorKeyFile>..\..\Autofac.snk</AssemblyOriginatorKeyFile>
-    <CodeAnalysisRuleSet>..\..\build\Analyzers.ruleset</CodeAnalysisRuleSet>
-    <RepositoryUrl>https://github.com/autofac/Autofac.Mvc.Owin</RepositoryUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://autofac.org</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>Release notes are at https://github.com/autofac/Autofac.Mvc.Owin/releases</PackageReleaseNotes>
-    <Features>IOperation</Features>
-    <PackageId>Autofac.Mvc5.Owin</PackageId>
+    <!-- Assembly metadata -->
     <AssemblyName>Autofac.Integration.Mvc.Owin</AssemblyName>
+    <AssemblyTitle>Autofac.Integration.Mvc.Owin</AssemblyTitle>
+    <Description>OWIN support for the ASP.NET MVC 5 integration for Autofac.</Description>
+    <Copyright>Copyright © 2014 Autofac Contributors</Copyright>
     <Authors>Autofac Contributors</Authors>
     <Company>Autofac</Company>
     <Product>Autofac</Product>
+    <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Description>OWIN support for the ASP.NET MVC 5 Integration for Autofac</Description>
-    <Copyright>Copyright © 2014 Autofac Contributors</Copyright>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Frameworks and language features -->
+    <TargetFramework>net472</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Packaging -->
+    <PackageId>Autofac.Mvc5.Owin</PackageId>
+    <PackageTags>autofac;di;ioc;dependencyinjection</PackageTags>
+    <PackageReleaseNotes>Release notes are at https://github.com/autofac/Autofac.Mvc.Owin/releases</PackageReleaseNotes>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageProjectUrl>https://autofac.org</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/autofac/Autofac.Mvc.Owin</RepositoryUrl>
+    <ContinuousIntegrationBuild Condition="'$(CI)' != '' ">true</ContinuousIntegrationBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedAllSources>true</EmbedAllSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\..\build\icon.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
+    <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,25 +56,14 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="[6.0.0, 7.0.0)" />
     <PackageReference Include="Autofac.Owin" Version="[6.0.0, 7.0.0)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>All</PrivateAssets>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>Autofac.Integration.Mvc.Owin.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001008728425885ef385e049261b18878327dfaaf0d666dea3bd2b0e4f18b33929ad4e5fbc9087e7eda3c1291d2de579206d9b4292456abffbe8be6c7060b36da0c33b883e3878eaf7c89fddf29e6e27d24588e81e86f3a22dd7b1a296b5f06fbfb500bbd7410faa7213ef4e2ce7622aefc03169b0324bcd30ccfe9ac8204e4960be6</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-
 </Project>

--- a/src/Autofac.Integration.Mvc.Owin/AutofacMvcAppBuilderExtensions.cs
+++ b/src/Autofac.Integration.Mvc.Owin/AutofacMvcAppBuilderExtensions.cs
@@ -1,42 +1,40 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.ComponentModel;
 using System.Web;
 using Autofac;
 using Autofac.Integration.Owin;
 
-namespace Owin
+namespace Owin;
+
+/// <summary>
+/// Extension methods for configuring the OWIN pipeline.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class AutofacMvcAppBuilderExtensions
 {
     /// <summary>
-    /// Extension methods for configuring the OWIN pipeline.
+    /// Gets or sets a factory method for creating <see cref="HttpContextBase"/> instances.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static class AutofacMvcAppBuilderExtensions
-    {
-        /// <summary>
-        /// Gets or sets a factory method for creating <see cref="HttpContextBase"/> instances.
-        /// </summary>
-        internal static Func<HttpContextBase> CurrentHttpContext { get; set; } = () => new HttpContextWrapper(HttpContext.Current);
+    internal static Func<HttpContextBase> CurrentHttpContext { get; set; } = () => new HttpContextWrapper(HttpContext.Current);
 
-        /// <summary>
-        /// Extends the Autofac lifetime scope added from the OWIN pipeline through to the MVC request lifetime scope.
-        /// </summary>
-        /// <param name="app">The application builder.</param>
-        /// <returns>The application builder for continued configuration.</returns>
-        public static IAppBuilder UseAutofacMvc(this IAppBuilder app) =>
-            app.Use(async (context, next) =>
+    /// <summary>
+    /// Extends the Autofac lifetime scope added from the OWIN pipeline through to the MVC request lifetime scope.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    /// <returns>The application builder for continued configuration.</returns>
+    public static IAppBuilder UseAutofacMvc(this IAppBuilder app) =>
+        app.Use(async (context, next) =>
+        {
+            var lifetimeScope = context.GetAutofacLifetimeScope();
+            var httpContext = CurrentHttpContext();
+
+            if (lifetimeScope != null && httpContext != null)
             {
-                var lifetimeScope = context.GetAutofacLifetimeScope();
-                var httpContext = CurrentHttpContext();
+                httpContext.Items[typeof(ILifetimeScope)] = lifetimeScope;
+            }
 
-                if (lifetimeScope != null && httpContext != null)
-                {
-                    httpContext.Items[typeof(ILifetimeScope)] = lifetimeScope;
-                }
-
-                await next().ConfigureAwait(false);
-            });
-    }
+            await next().ConfigureAwait(false);
+        });
 }

--- a/src/Autofac.Integration.Mvc.Owin/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Integration.Mvc.Owin/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: InternalsVisibleTo("Autofac.Integration.Mvc.Owin.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001008728425885ef385e049261b18878327dfaaf0d666dea3bd2b0e4f18b33929ad4e5fbc9087e7eda3c1291d2de579206d9b4292456abffbe8be6c7060b36da0c33b883e3878eaf7c89fddf29e6e27d24588e81e86f3a22dd7b1a296b5f06fbfb500bbd7410faa7213ef4e2ce7622aefc03169b0324bcd30ccfe9ac8204e4960be6")]
+[assembly: CLSCompliant(false)]
+[assembly: ComVisible(false)]

--- a/test/Autofac.Integration.Mvc.Owin.Test/Autofac.Integration.Mvc.Owin.Test.csproj
+++ b/test/Autofac.Integration.Mvc.Owin.Test/Autofac.Integration.Mvc.Owin.Test.csproj
@@ -2,15 +2,26 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\Autofac.snk</AssemblyOriginatorKeyFile>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="TestResults\**" />
     <EmbeddedResource Remove="TestResults\**" />
     <None Remove="TestResults\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,18 +33,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.1.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.core" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/test/Autofac.Integration.Mvc.Owin.Test/AutofacMvcAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.Mvc.Owin.Test/AutofacMvcAppBuilderExtensionsFixture.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Threading.Tasks;
 using System.Web;
 using Microsoft.Owin.Testing;
 using Moq;
@@ -9,33 +8,32 @@ using Owin;
 using Xunit;
 using OwinExtensions = Owin.AutofacMvcAppBuilderExtensions;
 
-namespace Autofac.Integration.Mvc.Owin.Test
+namespace Autofac.Integration.Mvc.Owin.Test;
+
+public class AutofacMvcAppBuilderExtensionsFixture
 {
-    public class AutofacMvcAppBuilderExtensionsFixture
+    [Fact]
+    public async Task UseAutofacMvcUpdatesHttpContextWithLifetimeScopeFromOwinContext()
     {
-        [Fact]
-        public async Task UseAutofacMvcUpdatesHttpContextWithLifetimeScopeFromOwinContext()
+        var builder = new ContainerBuilder();
+        builder.RegisterType<TestMiddleware>();
+        var container = builder.Build();
+
+        var httpContext = new Mock<HttpContextBase>();
+        httpContext.SetupSet(mock => mock.Items[typeof(ILifetimeScope)] = It.IsAny<ILifetimeScope>()).Verifiable();
+        OwinExtensions.CurrentHttpContext = () => httpContext.Object;
+
+        using (var server = TestServer.Create(app =>
         {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<TestMiddleware>();
-            var container = builder.Build();
+            app.UseAutofacMiddleware(container);
+            app.UseAutofacMvc();
+            app.Run(context => context.Response.WriteAsync("Hello, world!"));
+        }))
+        {
+            await server.HttpClient.GetAsync("/");
+            httpContext.VerifyAll();
 
-            var httpContext = new Mock<HttpContextBase>();
-            httpContext.SetupSet(mock => mock.Items[typeof(ILifetimeScope)] = It.IsAny<ILifetimeScope>()).Verifiable();
-            OwinExtensions.CurrentHttpContext = () => httpContext.Object;
-
-            using (var server = TestServer.Create(app =>
-            {
-                app.UseAutofacMiddleware(container);
-                app.UseAutofacMvc();
-                app.Run(context => context.Response.WriteAsync("Hello, world!"));
-            }))
-            {
-                await server.HttpClient.GetAsync("/");
-                httpContext.VerifyAll();
-
-                Assert.NotNull(TestMiddleware.LifetimeScope);
-            }
+            Assert.NotNull(TestMiddleware.LifetimeScope);
         }
     }
 }

--- a/test/Autofac.Integration.Mvc.Owin.Test/Properties/AssemblyInfo.cs
+++ b/test/Autofac.Integration.Mvc.Owin.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+[assembly: CLSCompliant(false)]
+[assembly: ComVisible(false)]

--- a/test/Autofac.Integration.Mvc.Owin.Test/TestMiddleware.cs
+++ b/test/Autofac.Integration.Mvc.Owin.Test/TestMiddleware.cs
@@ -1,26 +1,24 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Threading.Tasks;
 using Autofac.Integration.Owin;
 using Microsoft.Owin;
 
-namespace Autofac.Integration.Mvc.Owin.Test
+namespace Autofac.Integration.Mvc.Owin.Test;
+
+public class TestMiddleware : OwinMiddleware
 {
-    public class TestMiddleware : OwinMiddleware
+    public TestMiddleware(OwinMiddleware next)
+        : base(next)
     {
-        public TestMiddleware(OwinMiddleware next)
-            : base(next)
-        {
-            LifetimeScope = null;
-        }
+        LifetimeScope = null;
+    }
 
-        public static ILifetimeScope LifetimeScope { get; private set; }
+    public static ILifetimeScope LifetimeScope { get; private set; }
 
-        public override Task Invoke(IOwinContext context)
-        {
-            LifetimeScope = context.GetAutofacLifetimeScope();
-            return Next.Invoke(context);
-        }
+    public override Task Invoke(IOwinContext context)
+    {
+        LifetimeScope = context.GetAutofacLifetimeScope();
+        return Next.Invoke(context);
     }
 }


### PR DESCRIPTION
- Build updated to use .NET 6 SDK but target .NET 4.7.2.
  - Analyzers updated, issues resolved.
  - File-scoped namespaces.
  - Implicit usings.
  - Publishing .snupkg symbols.
  - README formatted for packaging.
- Closes #8: Updates the Autofac.Owin compatibility to 7.0.0 and removes the version range qualifier.