### PR TITLE
Convert from Moq to NSubstitute

### DIFF
--- a/test/Autofac.Integration.Mvc.Owin.Test/Autofac.Integration.Mvc.Owin.Test.csproj
+++ b/test/Autofac.Integration.Mvc.Owin.Test/Autofac.Integration.Mvc.Owin.Test.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.1.1" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Integration.Mvc.Owin.Test/AutofacMvcAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.Mvc.Owin.Test/AutofacMvcAppBuilderExtensionsFixture.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections;
 using System.Web;
 using Microsoft.Owin.Testing;
-using Moq;
+using NSubstitute;
 using Owin;
 using Xunit;
 using OwinExtensions = Owin.AutofacMvcAppBuilderExtensions;
@@ -19,9 +20,10 @@ public class AutofacMvcAppBuilderExtensionsFixture
         builder.RegisterType<TestMiddleware>();
         var container = builder.Build();
 
-        var httpContext = new Mock<HttpContextBase>();
-        httpContext.SetupSet(mock => mock.Items[typeof(ILifetimeScope)] = It.IsAny<ILifetimeScope>()).Verifiable();
-        OwinExtensions.CurrentHttpContext = () => httpContext.Object;
+        var items = new Hashtable();
+        var httpContext = Substitute.For<HttpContextBase>();
+        httpContext.Items.Returns(items);
+        OwinExtensions.CurrentHttpContext = () => httpContext;
 
         using (var server = TestServer.Create(app =>
         {
@@ -31,7 +33,7 @@ public class AutofacMvcAppBuilderExtensionsFixture
         }))
         {
             await server.HttpClient.GetAsync("/");
-            httpContext.VerifyAll();
+            Assert.IsAssignableFrom<ILifetimeScope>(items[typeof(ILifetimeScope)]);
 
             Assert.NotNull(TestMiddleware.LifetimeScope);
         }


### PR DESCRIPTION
## Summary
- Replace Moq with NSubstitute 5.3.0
- Convert `Mock<HttpContextBase>` with SetupSet/VerifyAll to NSubstitute pattern using a real `Hashtable` for Items
- Part of cross-repo effort to standardize on NSubstitute

## Test plan
- [ ] CI build passes (net472 project, cannot build locally on macOS)